### PR TITLE
Solved Issue #8 Uneven Card heights in Resources Section [GSSOC'23]

### DIFF
--- a/frontend/src/component/category/category.css
+++ b/frontend/src/component/category/category.css
@@ -46,3 +46,7 @@
     margin-inline: auto;
     border-radius: var(--radius-5);
 }
+
+.grid-list .category-card {
+    height: 100%;
+}

--- a/frontend/src/component/stats/stat.css
+++ b/frontend/src/component/stats/stat.css
@@ -3,6 +3,7 @@
     text-align: center;
     padding: 25px;
     border-radius: var(--radius-10);
+    height: 100%;
 }
 
 .stats-card :is(.card-title, .card-text) {


### PR DESCRIPTION
[fix] Uneven height of Cards in resources section.
[fix] Uneven height of Cards in Stats section.

Close #8 

| Before | After |
|---|---|
| ![image](https://github.com/Resourcio-Community/Resourcio_Community-Website/assets/91585213/c4e36d0c-e4c1-424e-800d-0bbcda29188e) | ![image](https://github.com/Resourcio-Community/Resourcio_Community-Website/assets/91585213/4c1bb956-d22b-4b1c-901f-5f496b734e13) |
