### PR TITLE
 Update Color Codes for GitHub and Discord Logos

### DIFF
--- a/frontend/src/component/footer/footer.css
+++ b/frontend/src/component/footer/footer.css
@@ -79,12 +79,11 @@
 }
 
 .social-list li:nth-child(5) .social-link:hover {
-    color: #ffffff;
-    opacity: 0.7;
+    color: #666667;
 }
 
 .social-list li:nth-child(6) .social-link:hover {
-    color: #7983F5;
+    color: #7289d9;
 }
 
 .footer-bottom {


### PR DESCRIPTION
### Description

This pull request aims to update the color codes used for the GitHub and Discord logos to reflect their refreshed visual identities.
resolves #351 

### Changes Made:

Updated the color code for the GitHub logo to "# 666667"
Updated the color code for the Discord logo to "# 7289d9"

### Reason for Changes:

Both GitHub and Discord have recently introduced slight modifications to their color palettes to enhance their visual identities and user experiences. These changes are consistent with their commitment to staying dynamic and engaging.